### PR TITLE
Bug fix. Add conditional on JS accordion block

### DIFF
--- a/src/frontend.js
+++ b/src/frontend.js
@@ -4,4 +4,9 @@
  */
 
 import { Accordion } from 'govuk-frontend';
-new Accordion(document.querySelector('[data-module="govuk-accordion"]')).init();
+
+const mojblocksAccordion = document.querySelector('[data-module="govuk-accordion"]');
+
+if (mojblocksAccordion || null) {
+    new Accordion(mojblocksAccordion).init();
+}


### PR DESCRIPTION
Check if no accordion block being used, default to null so that error is
not thrown.