### PR TITLE
Bug fix, formatting and adding some WP meta

### DIFF
--- a/mojblocks.php
+++ b/mojblocks.php
@@ -1,18 +1,28 @@
 <?php
 
 /**
+ *
+ * The file responsible for starting the mojblocks plugin
+ *
+ * These Gutenberg blocks support custom MoJ block functionality we're
+ * not able to incorporate into our theme or third party blocks/plugins.
+ *
+ * @package mojblocks
+ *
  * Plugin name: MoJ Blocks
  * Plugin URI:  https://github.com/ministryofjustice/wp-moj-blocks
  * Description: Introduces various functions that are commonly used across the MoJ network of sites
  * Version:     1.0.0
  * Author:      Ministry of Justice
  * Text domain: mojblocks
- * Author URI:  https://ministryofjustice.github.io/justice-on-the-web/#justice-on-the-web
+ * Author URI:  https://github.com/ministryofjustice
  * License:     MIT License
+ * License URI: https://opensource.org/licenses/MIT
+ * Copyright:   Crown Copyright (c) Ministry of Justice
  **/
 
 defined('ABSPATH') || exit;
-
+ 
 /**
  * Load translations (if any) for the plugin from the /languages/ folder.
  *
@@ -45,7 +55,6 @@ add_filter('block_categories', 'mojblocks_block_categories', 10, 2);
  */
 function mojblocks_block_categories($categories, $post)
 {
-
     return array_merge(
         $categories,
         array(
@@ -76,7 +85,23 @@ function mojblocks_register_blocks()
         return;
     }
 
-    $meta = require_once('build/index.asset.php');
+    // Check if build file hasn't been generated and is missing
+    $file_exists = file_exists(plugin_dir_path(__FILE__) . 'build/index.asset.php');
+
+    if ($file_exists) {
+        $meta = require_once('build/index.asset.php');
+    } else {
+        $meta = [
+            'dependencies' => [],
+            'version' => '20200723'
+        ];
+
+        trigger_error(
+            'Build file does not exist, run NPM run build',
+            E_USER_WARNING
+        );
+    }
+
     // Register the block editor script.
     wp_register_script(
         'mojblocks-editor-script',                  // label.
@@ -95,7 +120,6 @@ function mojblocks_register_blocks()
     );
     register_block_type('mojblocks/example');
 }
-
 
 /**
  * Queues up the gutenberg editor style

--- a/mojblocks.php
+++ b/mojblocks.php
@@ -57,13 +57,13 @@ function mojblocks_block_categories($categories, $post)
 {
     return array_merge(
         $categories,
-        array(
-            array(
+        [
+            [
                 'slug' => 'mojblocks',
                 'title' => __('MOJ Blocks', 'mojblocks'),
                 'icon' => 'screen',
-            ),
-        )
+            ],
+        ]
     );
 }
 
@@ -104,21 +104,18 @@ function mojblocks_register_blocks()
 
     // Register the block editor script.
     wp_register_script(
-        'mojblocks-editor-script',                  // label.
-        plugins_url('/build/index.js', __FILE__),   // script file.
-        $meta['dependencies'] ?? [],                // dependencies.
+        'mojblocks-editor-script',
+        plugins_url('/build/index.js', __FILE__),
+        $meta['dependencies'] ?? [],
         $meta['version'] ?? '20200723',
         true
     );
 
+     // Calls registered script above. Registering one brings all. One block to rule them all.
     register_block_type(
-        'mojblocks/panel1',
-        array(
-            'editor_script' => 'mojblocks-editor-script',
-            // Calls registered script above. Registering one brings all. One block to rule them all.
-        )
+        'mojblocks/blocks',
+        ['editor_script' => 'mojblocks-editor-script']
     );
-    register_block_type('mojblocks/example');
 }
 
 /**


### PR DESCRIPTION
Build folder is dynamic and if you try running the plugin without it the plugin will crash and throw a fatal error. Small check added if the build folder hasn't been generated yet. This is mostly a change for devs, as in prod we'll always have a build folder. 

Some formatting for consistency and I've added some WP plugin meta.