### PR TITLE
Accordion scss fix

### DIFF
--- a/src/01-highlights-list/style.scss
+++ b/src/01-highlights-list/style.scss
@@ -6,6 +6,9 @@ Author:  Ministry of Justice - Damien Wilson
 
 **********************************************************************************************/
 
+// include the entire govuk frontend library in the editor
+@import 'node_modules/govuk-frontend/govuk/all';
+
 /** Variables */
 $mojblocks-color-teal: #336C83;
 $mojblocks-color-yellow: #FFDD00;

--- a/src/04-accordion/govuk.scss
+++ b/src/04-accordion/govuk.scss
@@ -1,9 +1,0 @@
-/**
-* This file contains imported styling to support GOV UK Frontend usage in the plugin
-*
-* To import styles from govuk-frontend in another block, simply include this file
-* in the block component and add your @imports with an online reference, like this:
-*
-* // https://design-system.service.gov.uk/components/accordion/
-* @import "node_modules/govuk-frontend/govuk/components/accordion/accordion";
-**/

--- a/src/04-accordion/style.scss
+++ b/src/04-accordion/style.scss
@@ -7,6 +7,16 @@ Text Domain: mojblocks
 
 **********************************************************************************************/
 
+/**
+* This file contains imported styling to support GOV UK Frontend usage in the plugin
+*
+* To import styles from govuk-frontend, simply include the Gov UK module using
+*  @imports with a URL reference
+**/
+
+// https://design-system.service.gov.uk/components/accordion/
+@import "node_modules/govuk-frontend/govuk/components/accordion/accordion";
+
 /** Variables */
 $mojblocks-color-light-blue: #1d70b8;
 $mojblocks-color-light-grey: #C7CDD0;

--- a/style-gutenburg.scss
+++ b/style-gutenburg.scss
@@ -12,8 +12,6 @@ Text Domain: mojblocks
 .edit-post-visual-editor,
 .block-editor-block-styles,
 .block-editor-inserter__menu-help-panel {
-    // include the entire govuk frontend library in the editor
-    @import 'node_modules/govuk-frontend/govuk/all';
     // load editor specific styles
     @import 'src/**/editor.scss';
 }

--- a/style.scss
+++ b/style.scss
@@ -14,10 +14,6 @@ Text Domain: mojblocks
 @import 'node_modules/govuk-frontend/govuk/base';
 @import 'node_modules/govuk-frontend/govuk/core/all';
 @import 'node_modules/govuk-frontend/govuk/objects/all';
-
-/// Individual component styles are pulled in from the blocks.
-@import 'src/**/govuk.scss';
-
 @import 'node_modules/govuk-frontend/govuk/utilities/all';
 @import 'node_modules/govuk-frontend/govuk/overrides/all';
 


### PR DESCRIPTION
Accordion wasn't loading because @import had been commented out when files got moved around. Some further changes here reflect an effort to 1.) import Gov UK styles in their modules rather then the whole library (if possible), and 2.) I think we should enforce the simplicity of having two stylesheets to mange per block, one for the front and one for the backend styles. This is of course open to debate in the team!