### PR TITLE
Tweak MoJ blocks to work on Hale theme

### DIFF
--- a/build/style-gutenburg.css
+++ b/build/style-gutenburg.css
@@ -5379,6 +5379,13 @@ Block: Staggered Box (Frontend styles)
   background-color: #1d70b8;
 }
 
+.edit-post-visual-editor .wp-block-mojblocks-cta .govuk-grid-row,
+.block-editor-block-styles .wp-block-mojblocks-cta .govuk-grid-row,
+.block-editor-inserter__menu-help-panel .wp-block-mojblocks-cta .govuk-grid-row {
+  margin-right: 0;
+  margin-left: 0;
+}
+
 .edit-post-visual-editor .wp-block-mojblocks-cta .mojblocks-cta__heading,
 .block-editor-block-styles .wp-block-mojblocks-cta .mojblocks-cta__heading,
 .block-editor-inserter__menu-help-panel .wp-block-mojblocks-cta .mojblocks-cta__heading {
@@ -5629,8 +5636,8 @@ Block: Staggered Box (Frontend styles)
   .edit-post-visual-editor .mojblocks-hero__overlay .govuk-grid-column-three-quarters,
   .block-editor-block-styles .mojblocks-hero__overlay .govuk-grid-column-three-quarters,
   .block-editor-inserter__menu-help-panel .mojblocks-hero__overlay .govuk-grid-column-three-quarters {
-    padding-left: 24px;
-    padding-left: 1.5rem;
+    padding-left: 16px;
+    padding-left: 1rem;
   }
 }
 
@@ -5672,6 +5679,13 @@ Block: Staggered Box (Frontend styles)
   .block-editor-inserter__menu-help-panel .wp-block-mojblocks-highlights-list {
     padding: 35px 0 25px;
   }
+}
+
+.edit-post-visual-editor .wp-block-mojblocks-highlights-list .govuk-grid-row,
+.block-editor-block-styles .wp-block-mojblocks-highlights-list .govuk-grid-row,
+.block-editor-inserter__menu-help-panel .wp-block-mojblocks-highlights-list .govuk-grid-row {
+  margin-right: 0;
+  margin-left: 0;
 }
 
 .edit-post-visual-editor .wp-block-mojblocks-highlights-list .mojblocks-highlights-list__heading,
@@ -6439,6 +6453,8 @@ Block: Staggered Box (Frontend styles)
 .block-editor-block-styles .mojblocks-staggered-box .govuk-grid-row,
 .block-editor-inserter__menu-help-panel .mojblocks-staggered-box .govuk-grid-row {
   position: relative;
+  margin-right: 0;
+  margin-left: 0;
 }
 
 @media (min-width: 40.0625em) {

--- a/build/style.min.css
+++ b/build/style.min.css
@@ -3044,6 +3044,11 @@ Block: Call to Action (Frontend styles)
   background-color: #1d70b8;
 }
 
+.wp-block-mojblocks-cta .govuk-grid-row {
+  margin-right: 0;
+  margin-left: 0;
+}
+
 .wp-block-mojblocks-cta .mojblocks-cta__heading {
   margin: 12px 0 15px;
   padding: 0;
@@ -3232,8 +3237,8 @@ Block: Hero (Frontend styles)
 
 @media (min-width: 40.0625em) {
   .mojblocks-hero__overlay .govuk-grid-column-three-quarters {
-    padding-left: 24px;
-    padding-left: 1.5rem;
+    padding-left: 16px;
+    padding-left: 1rem;
   }
 }
 
@@ -3271,6 +3276,11 @@ Block: Highlights List (Frontend styles)
   .wp-block-mojblocks-highlights-list {
     padding: 35px 0 25px;
   }
+}
+
+.wp-block-mojblocks-highlights-list .govuk-grid-row {
+  margin-right: 0;
+  margin-left: 0;
 }
 
 .wp-block-mojblocks-highlights-list .mojblocks-highlights-list__heading {
@@ -3663,6 +3673,8 @@ Block: Staggered Box (Frontend styles)
 
 .mojblocks-staggered-box .govuk-grid-row {
   position: relative;
+  margin-right: 0;
+  margin-left: 0;
 }
 
 @media (min-width: 40.0625em) {

--- a/build/style.min.css
+++ b/build/style.min.css
@@ -2906,8 +2906,6 @@ SASS modifications to conform GovUK frontend to MoJ block styling
 
 .govuk-accordion__section-heading {
   margin-bottom: 0;
-  margin-left: 22px;
-  margin-left: 1.375rem;
 }
 
 .govuk-accordion__section-heading h4 {
@@ -2956,7 +2954,7 @@ SASS modifications to conform GovUK frontend to MoJ block styling
 }
 
 .govuk-accordion:last-child {
-  border-bottom: 1px solid #B1B4B6;
+  border-bottom: 1px solid #F3F2F1;
 }
 
 /*********************************************************************************************

--- a/build/style.min.css
+++ b/build/style.min.css
@@ -2919,10 +2919,10 @@ SASS modifications to conform GovUK frontend to MoJ block styling
 }
 
 .govuk-accordion__section-content .govuk-body {
-  margin-left: 16px;
-  margin-left: 1rem;
-  padding-left: 30px;
-  padding-left: 1.875rem;
+  margin-left: 14px;
+  margin-left: 0.875rem;
+  padding-left: 14px;
+  padding-left: 0.875rem;
 }
 
 .govuk-accordion__section--expanded .govuk-accordion__section-heading:before {

--- a/build/style.min.css
+++ b/build/style.min.css
@@ -2885,7 +2885,7 @@ SASS modifications to conform GovUK frontend to MoJ block styling
   font-family: inherit;
   font-size: inherit;
   border-bottom: none;
-  margin-bottom: 0;
+  margin-bottom: 24px;
 }
 
 .govuk-accordion h1,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4554,21 +4554,6 @@
             "semver": "^6.0.0"
           }
         },
-        "mime-db": {
-          "version": "1.44.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-          "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.27",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-          "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.44.0"
-          }
-        },
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -4633,26 +4618,6 @@
           "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5.tgz",
           "integrity": "sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A==",
           "dev": true
-        },
-        "puppeteer": {
-          "version": "npm:puppeteer-core@3.0.0",
-          "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-3.0.0.tgz",
-          "integrity": "sha512-oWjZFGMc0q2ak+8OxdmMffS79LIT0UEtmpV4h1/AARvESIqqKljf8mrfP+dQ2kas7XttsAZIxRBuWu7Y5JH8KQ==",
-          "dev": true,
-          "requires": {
-            "@types/mime-types": "^2.1.0",
-            "debug": "^4.1.0",
-            "extract-zip": "^2.0.0",
-            "https-proxy-agent": "^4.0.0",
-            "mime": "^2.0.3",
-            "mime-types": "^2.1.25",
-            "progress": "^2.0.1",
-            "proxy-from-env": "^1.0.0",
-            "rimraf": "^3.0.2",
-            "tar-fs": "^2.0.0",
-            "unbzip2-stream": "^1.3.3",
-            "ws": "^7.2.3"
-          }
         },
         "rimraf": {
           "version": "3.0.2",
@@ -6586,13 +6551,13 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.0.tgz",
+          "integrity": "sha512-cd+5r1VLBwUqTrmnzW+D7ABkJUM6mr7uv1dv+6jRw4Rcl7tFIFHDqHPL98LhpGFn3dbAt3gtLxtrWp4m1kFrqg==",
           "dev": true,
           "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
           }
         },
         "readable-stream": {
@@ -20436,6 +20401,52 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "puppeteer": {
+      "version": "npm:puppeteer-core@3.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-3.0.0.tgz",
+      "integrity": "sha512-oWjZFGMc0q2ak+8OxdmMffS79LIT0UEtmpV4h1/AARvESIqqKljf8mrfP+dQ2kas7XttsAZIxRBuWu7Y5JH8KQ==",
+      "dev": true,
+      "requires": {
+        "@types/mime-types": "^2.1.0",
+        "debug": "^4.1.0",
+        "extract-zip": "^2.0.0",
+        "https-proxy-agent": "^4.0.0",
+        "mime": "^2.0.3",
+        "mime-types": "^2.1.25",
+        "progress": "^2.0.1",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^3.0.2",
+        "tar-fs": "^2.0.0",
+        "unbzip2-stream": "^1.3.3",
+        "ws": "^7.2.3"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.44.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+          "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.27",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+          "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+          "dev": true,
+          "requires": {
+            "mime-db": "1.44.0"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
     },
     "q": {
       "version": "1.5.1",

--- a/src/accordion/editor.scss
+++ b/src/accordion/editor.scss
@@ -35,7 +35,7 @@ SASS modifications to conform GovUK frontend to MoJ block styling
             padding-left: 0;
             margin-left: 0;
         }
-    }  
+    }
 }
 
 

--- a/src/accordion/style.scss
+++ b/src/accordion/style.scss
@@ -67,10 +67,7 @@ SASS modifications to conform GovUK frontend to MoJ block styling
             font-family: inherit;
             font-size: inherit;
         }
-
-        margin-left: 22px;
-        margin-left: govuk-px-to-rem(22);
-    }
+	}
 
     &__section-content {
         // Decrease padding causes by NHS styles around accordion content
@@ -124,6 +121,6 @@ SASS modifications to conform GovUK frontend to MoJ block styling
 
     // Add a bottom border to last accordion section
     &:last-child {
-        border-bottom: 1px solid $mojblocks-color-mid-grey;
+        border-bottom: 1px solid $mojblocks-color-light-grey;
     }
 }

--- a/src/accordion/style.scss
+++ b/src/accordion/style.scss
@@ -75,10 +75,10 @@ SASS modifications to conform GovUK frontend to MoJ block styling
 
         // Indent body text in accordion section content to align with title
         .govuk-body {
-			margin-left: 16px;
-			margin-left: govuk-px-to-rem(16);
-            padding-left: 30px;
-            padding-left: govuk-px-to-rem(30);
+			margin-left: 14px;
+			margin-left: govuk-px-to-rem(14);
+            padding-left: 14px;
+            padding-left: govuk-px-to-rem(14);
         }
     }
 

--- a/src/accordion/style.scss
+++ b/src/accordion/style.scss
@@ -30,9 +30,7 @@ SASS modifications to conform GovUK frontend to MoJ block styling
     font-family: inherit;
     font-size: inherit;
     border-bottom: none;
-
-    // Reset NHS margin to display no margin on accordion sections
-    margin-bottom: 0;
+    margin-bottom: 24px;
 
     h1,
     h2,

--- a/src/cta/style.scss
+++ b/src/cta/style.scss
@@ -8,8 +8,13 @@ Block: Call to Action (Frontend styles)
 .wp-block-mojblocks-cta {
     padding: 15px;
     margin: auto -15px;
-    background-color: $mojblocks-color-light-blue;
+	background-color: $mojblocks-color-light-blue;
 
+	.govuk-grid-row {
+		// Gov UK override keeping the block within the container.
+		margin-right: 0;
+		margin-left: 0;
+	}
     .mojblocks-cta {
 
         &__heading {

--- a/src/hero/style.scss
+++ b/src/hero/style.scss
@@ -38,8 +38,8 @@ Block: Hero (Frontend styles)
     & .govuk-grid-column-three-quarters {
 
       @include govuk-media-query($from: tablet) {
-        padding-left: 24px;
-        padding-left: govuk-px-to-rem(24);
+        padding-left: 16px;
+        padding-left: govuk-px-to-rem(16);
       }
     }
 

--- a/src/highlights-list/style.scss
+++ b/src/highlights-list/style.scss
@@ -16,7 +16,13 @@ Block: Highlights List (Frontend styles)
 
     @include govuk-media-query($from: desktop) {
         padding: 35px 0 25px;
-    }
+	}
+
+	.govuk-grid-row {
+		// Gov UK override keeping the block within the container.
+		margin-right: 0;
+		margin-left: 0;
+	}
 
     .mojblocks-highlights-list {
 

--- a/src/staggered-boxes/style.scss
+++ b/src/staggered-boxes/style.scss
@@ -11,6 +11,10 @@ Block: Staggered Box (Frontend styles)
 
 	& .govuk-grid-row {
 		position: relative;
+
+		// Gov UK override keeping the block within the container.
+		margin-right: 0;
+		margin-left: 0;
 	}
 
 	@include govuk-media-query($from: tablet) {


### PR DESCRIPTION
- Created an override on all blocks that removes the negative -15 margin, that pushed content outside of the NHS theme container. When we choose a new framework, we can either keep or remove this margin override but in the meantime our blocks now sit within the container.

- Added a bottom margin on the accordion block so that headers don't sit flush against it.