### PR TITLE
Hero Block tweaks for FEF

### DIFF
--- a/src/hero/style.scss
+++ b/src/hero/style.scss
@@ -20,7 +20,7 @@ Block: Hero (Frontend styles)
 
   &__image {
     background: #336C83;
-    width: 100vw;
+    width: 101vw;
     min-height: 250px;
     min-height: govuk-px-to-rem(250);
 

--- a/src/hero/style.scss
+++ b/src/hero/style.scss
@@ -13,6 +13,11 @@ Block: Hero (Frontend styles)
   margin-left: -50vw;
   margin-right: -50vw;
 
+	.govuk-grid-row {
+		margin-left:0;
+		margin-right:0;
+	}
+
   &__image {
     background: #336C83;
     width: 100vw;


### PR DESCRIPTION
Changed `.mojblocks-hero__image` width to `101vw` so that MacOS users don't get a gap betwixt the hero image and the scrollbar - not discernible on Windows.
Reduced the margin of the text overlay to 0 - so the text isn't off-centre on narrow desktop displays.  