### PR TITLE
Staggered box tweaks for FEF

### DIFF
--- a/src/staggered-box/style.scss
+++ b/src/staggered-box/style.scss
@@ -41,7 +41,7 @@ Block: Staggered Box (Frontend styles)
 
 	}
 
-	&__text-container.govuk-grid-column-one-half { {
+	&__text-container.govuk-grid-column-one-half {
 
 		z-index: 1;
 		background-color: $mojblocks-color-grey;

--- a/src/staggered-box/style.scss
+++ b/src/staggered-box/style.scss
@@ -41,7 +41,7 @@ Block: Staggered Box (Frontend styles)
 
 	}
 
-	&__text-container {
+	&__text-container.govuk-grid-column-one-half { {
 
 		z-index: 1;
 		background-color: $mojblocks-color-grey;


### PR DESCRIPTION
Made the CSS more specific by adding the govuk class to the stylesheet and bump the specific styling up the hierarchy.  This prevents the GDS Design System styling from overriding the positioning of the staggered box. 