### PR TITLE
Banner button styling for FEF

### DIFF
--- a/src/banner/index.php
+++ b/src/banner/index.php
@@ -36,7 +36,7 @@ function render_callback_banner_block($attributes, $content)
                     </h1>
                 </div>
                 <div class="govuk-grid-column-one-third">
-                    <a href="<?php _e($attribute_button_link); ?>" class="mojblocks-banner__button">
+                    <a href="<?php _e($attribute_button_link); ?>" class="mojblocks-banner__button govuk-button">
                         <?php _e(esc_html($attribute_button_label)); ?>
                     </a>
                 </div>

--- a/src/banner/style.scss
+++ b/src/banner/style.scss
@@ -21,36 +21,14 @@ Block: Banner (Frontend styles)
 		}
 	}
 
-	&__button {
-		background: $mojblocks-color-sunflower-yellow;
-		color: $mojblocks-color-black;
-		padding: 6px 12px;
-		font-weight: bold;
-		text-decoration: none;
-		font-size: 22px;
-		font-size: 1.375rem;
-		display: block;
-		text-align: center;
-		border-radius: 5px;
+	&__button.govuk-button {
+		font-size: 24px;
+		font-size: govuk-px-to-rem(24);
+		font-weight: 700;
 
 		@include govuk-media-query($from: tablet) {
 			float: right;
-			font-size: 25px;
-			font-size: 1.5rem;
 			margin-top: 12px;
-			text-align: left;
-			padding: 3px 12px;
-		}
-
-		&:visited {
-			color: $mojblocks-color-black;
-			text-decoration: none;
-		}
-
-		&:hover, &:active, &:focus {
-			background: $mojblocks-color-black;
-			color: $mojblocks-color-white;
-			box-shadow: none;
 		}
 	}
 }


### PR DESCRIPTION
- Added a new class of `govuk-button` so the branding button style gets applied to the banner.
- Removed much of the bespoke button styling as this is now picked up from the branding.  
- Adjusted font sizes to match.