### PR TITLE
Accessibility improvements

### DIFF
--- a/src/custom-blocks/cta/index.php
+++ b/src/custom-blocks/cta/index.php
@@ -34,7 +34,7 @@ function render_callback_cta_block($attributes, $content)
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-three-quarters block-cancel-gds-width-if-flex-narrow">
                     <div class="mojblocks-cta__heading-container">
-                        <h2 class="mojblocks-cta__heading">
+                        <h2 class="govuk-heading-l mojblocks-cta__heading">
                             <span role="text">
                                 <span class="mojblocks-cta__heading-text">
                                     <?php _e(esc_html($attribute_cta_title)); ?>

--- a/src/custom-blocks/cta/style.scss
+++ b/src/custom-blocks/cta/style.scss
@@ -14,7 +14,7 @@ Block: Call to Action (Frontend styles)
     &.highlight-clipping:after {
         content: "";
         display: block;
-        height: calc(100% + 0.6em);
+        height: calc(100% + 5px);
         left: 50%;
         overflow: visible;
         position: absolute;
@@ -122,7 +122,11 @@ Block: Call to Action (Frontend styles)
 // In such cases, the flex basis is probably 66% so the text will already be reduced width
 // this relies on the current practice of style only having flex-basis
 @include govuk-media-query($from: tablet) {
-    .wp-block-column[style|="flex"]:not([style$="100%"]) .block-cancel-gds-width-if-flex-narrow {
-        width: 100%;
+    .wp-block-column[style|="flex"]:not([style$="100%"]) {
+        align-self: stretch;
+
+        .block-cancel-gds-width-if-flex-narrow {
+            width: 100%;
+        }
     }
 }


### PR DESCRIPTION
This is correcting the styling and class names in CTA, which was exposed when I worked on the accessibility improvements on the Hale repo.  

- stretch the CTA content block to always be the height of the second column so the highlighting doesn't cut off halfway down the image.
- added GDS heading class.
- tweaked highlighted height.