### PR TITLE
CTA fix

### DIFF
--- a/mojblocks.php
+++ b/mojblocks.php
@@ -12,7 +12,7 @@
  * Plugin name: MoJ Blocks
  * Plugin URI:  https://github.com/ministryofjustice/wp-moj-blocks
  * Description: Introduces various functions that are commonly used across the MoJ network of sites
- * Version:     3.11.1
+ * Version:     3.11.2
  * Author:      Ministry of Justice - Adam Brown, Beverley Newing, Malcolm Butler, Damien Wilson & Robert Lowe
  * Text domain: mojblocks
  * Author URI:  https://github.com/ministryofjustice

--- a/src/custom-blocks/cta/index.php
+++ b/src/custom-blocks/cta/index.php
@@ -42,10 +42,8 @@ function render_callback_cta_block($attributes, $content)
                 <div class="govuk-grid-column-three-quarters block-cancel-gds-width-if-flex-narrow">
                     <div class="mojblocks-cta__heading-container">
                         <h2 class="govuk-heading-l mojblocks-cta__heading">
-                            <span role="text">
-                                <span class="mojblocks-cta__heading-text">
-                                    <?php _e(esc_html($attribute_cta_title)); ?>
-                                </span>
+                            <span class="mojblocks-cta__heading-text">
+                                <?php _e(esc_html($attribute_cta_title)); ?>
                             </span>
                         </h2>
                     </div>


### PR DESCRIPTION
As per accessibility team suggestion, removing the superfluous `<span role="text">` from the CTA block's heading.