### PR TITLE
Separator fix

### DIFF
--- a/mojblocks.php
+++ b/mojblocks.php
@@ -12,7 +12,7 @@
  * Plugin name: MoJ Blocks
  * Plugin URI:  https://github.com/ministryofjustice/wp-moj-blocks
  * Description: Introduces various functions that are commonly used across the MoJ network of sites
- * Version:     3.12.0
+ * Version:     3.12.1
  * Author:      Ministry of Justice - Adam Brown, Beverley Newing, Malcolm Butler, Damien Wilson & Robert Lowe
  * Text domain: mojblocks
  * Author URI:  https://github.com/ministryofjustice

--- a/src/custom-blocks/separator/index.php
+++ b/src/custom-blocks/separator/index.php
@@ -19,6 +19,7 @@ function render_callback_separator_block($attributes, $content)
     $attribute_line_size = $attributes['separatorThickness'] ?? '1';
     $attribute_line_colour = $attributes['separatorColour'] ?? '#b1b4b6';
     $attribute_width = $attributes['separatorWidth'] ?? '0';
+    $attribute_class_name = $attributes['className'] ?? '';
 
     // Sets the size of the gap around the line
     $gap_size = !empty($attribute_gap_size) ? "govuk-section-break--$attribute_gap_size" : '';
@@ -40,7 +41,7 @@ function render_callback_separator_block($attributes, $content)
     ?>
 
     <hr
-        class="alignfull govuk-section-break govuk-section-break--visible <?php echo $gap_size; ?>"
+        class="alignfull govuk-section-break govuk-section-break--visible <?php echo $gap_size; ?> <?php echo esc_html($attribute_class_name); ?>"
         <?php // alignfull is to prevent group block overriding the width ?>
         style="<?php echo $line_size.$line_hue.$line_width;?>"
     />

--- a/src/custom-blocks/separator/index.php
+++ b/src/custom-blocks/separator/index.php
@@ -40,7 +40,8 @@ function render_callback_separator_block($attributes, $content)
     ?>
 
     <hr
-        class="govuk-section-break govuk-section-break--visible <?php echo $gap_size; ?>"
+        class="alignfull govuk-section-break govuk-section-break--visible <?php echo $gap_size; ?>"
+        <?php // alignfull is to prevent group block overriding the width ?>
         style="<?php echo $line_size.$line_hue.$line_width;?>"
     />
 


### PR DESCRIPTION
The group block adds in strange margins with an `!important` if the class isn't one of three align classes, they don't act upon it.  
The separator block never has these classes.  This PR adds one to overcome this issue.  

The separator block php wasn't rendering the custom classname either - this fixes that oversight too.  