### PR TITLE
Deprecated styles

### DIFF
--- a/mojblocks.php
+++ b/mojblocks.php
@@ -12,7 +12,7 @@
  * Plugin name: MoJ Blocks
  * Plugin URI:  https://github.com/ministryofjustice/wp-moj-blocks
  * Description: Introduces various functions that are commonly used across the MoJ network of sites
- * Version:     3.15.0
+ * Version:     3.15.1
  * Author:      Ministry of Justice - Adam Brown, Beverley Newing, Malcolm Butler, Damien Wilson & Robert Lowe
  * Text domain: mojblocks
  * Author URI:  https://github.com/ministryofjustice

--- a/src/extended-core-blocks/heading/common.scss
+++ b/src/extended-core-blocks/heading/common.scss
@@ -3,7 +3,6 @@
 @include govuk-media-query($from: "tablet", $media-type: screen) {
 	h1, h2, h3, h4, h5, h6 {
 		max-width: 700px;
-		&:is(.hale-deprecated-paragraph-widths *), // Remove this when all sites have been updated
 		&.is-style-wide {
 			max-width: 1010px;
 		}

--- a/src/extended-core-blocks/list/common.scss
+++ b/src/extended-core-blocks/list/common.scss
@@ -2,7 +2,6 @@
 	ul, ol {
 		max-width: 666px;
 
-		&:is(.hale-deprecated-paragraph-widths *), // Remove this when all sites have been updated
 		&.is-style-wide {
 			max-width: 960px;
 		}

--- a/src/extended-core-blocks/paragraph/common.scss
+++ b/src/extended-core-blocks/paragraph/common.scss
@@ -1,7 +1,6 @@
 @include govuk-media-query($from: "tablet", $media-type: screen) {
 	p {
 		max-width: 666px;
-		&:is(.hale-deprecated-paragraph-widths *), // Remove this when all sites have been updated
 		&.is-style-wide {
 			max-width: 960px;
 		}


### PR DESCRIPTION
Removes the special styling for deprecated paragraphs now that all relevant sites have been updated to use the new "wide" settings.  