### PR TITLE
Moved file extension inside link for SR users

### DIFF
--- a/mojblocks.php
+++ b/mojblocks.php
@@ -12,7 +12,7 @@
  * Plugin name: MoJ Blocks
  * Plugin URI:  https://github.com/ministryofjustice/wp-moj-blocks
  * Description: Introduces various functions that are commonly used across the MoJ network of sites
- * Version:     3.19.4
+ * Version:     3.19.5
  * Author:      Ministry of Justice - Adam Brown, Beverley Newing, Malcolm Butler, Damien Wilson & Robert Lowe
  * Text domain: mojblocks
  * Author URI:  https://github.com/ministryofjustice

--- a/src/extended-core-blocks/file/index.php
+++ b/src/extended-core-blocks/file/index.php
@@ -64,6 +64,8 @@ function mojblocks_file_block_renderer($name, $attributes, $block_content)
     // Return a file name with the extention removed and no trailing whitespace
     $filename = trim(preg_replace($pattern, '', $parsedHTML, 1));
 
+    $metadata = '<span>&#40;</span>'.esc_attr($extention).esc_attr($filesize).'<span>&#41;</span>';
+
     // Turn on buffering so we can collect all the html markup below and load it via the return
     // This is an alternative method to using sprintf(). By using buffering you can write your
     // code below as you would in any other PHP file rather then having to use the sprintf() syntax
@@ -72,10 +74,10 @@ function mojblocks_file_block_renderer($name, $attributes, $block_content)
     ?>
 
     <div class="mojblocks-file govuk-body">
-        <a href="<?php echo $attributes["href"]; ?>"><?php _e($filename, 'mojblocks'); ?></a>
+        <a href="<?php echo $attributes["href"]; ?>"><?php _e($filename, 'mojblocks'); ?><span class="govuk-visually-hidden"> <?php _e($metadata);?></span></a>
 
-        <div class="mojblocks-file__extention">
-            <span>&#40;</span><?php echo esc_attr($extention); ?><?php echo esc_attr($filesize); ?><span>&#41;</span>
+        <div class="mojblocks-file__extention" aria-hidden="true">
+            <?php _e($metadata);?>
         </div>
     </div>
 


### PR DESCRIPTION
- This adds the file metadata (type and size) to the link, so AT users have it read out as part of the link, rather than "floating" in the middle of nowhere, out of context.
- This also aria-hides the existing metadata, so it isn't repeated to AT users, but preserves the current visual look of having the metadata outwith the link.

MoJ Blocks version 3.19.5